### PR TITLE
remove arbmian-extras dependency and document alternatives

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,0 @@
-[submodule "submodules/ethereumonarm"]
-	path = submodules/ethereumonarm
-	url = https://github.com/luisnaranjo733/ethereumonarm.git

--- a/README.md
+++ b/README.md
@@ -1,11 +1,11 @@
 # ARM Node Tools
 ARM node tools is a set of blockchain agnostic, general purpose tools that facilitate the use of consensus nodes. This project specifically tests against the Raspberry Pi 4 Model B (8GB) hardware, but is meant to be theoretically usable on other ARM devices.
 
-Really, this project is just a Ubuntu based ARM image that you can customize and compile yourself. It won't install or configure any blockchain specific software for you, but it will help you bootstrap your ARM node so you can use it for whatever you want (Bitcoin, Ethereum, Cardano, Avalanche, whatever!). It's up to you to research and understand the requirements from the blockchain you are targeting. But even for energy intensive PoW blockchains like Bitcoin, it's possible to run a node with a low power ARM device as long as you aren't trying to mine with it.
+Really, this project is just a Ubuntu based ARM image that you can customize and compile yourself. It won't install or configure any blockchain specific software for you, but it will help you bootstrap your ARM node so you can use it for whatever you want (Bitcoin, Ethereum, Cardano, Avalanche, whatever!). It's up to you to research and understand the requirements from the blockchain you are targeting. But even for energy intensive PoW blockchains like Bitcoin, it's possible to run a consensus node with a low power ARM device as long as you aren't trying to mine with it.
 
 ## Goals
 1. Promote and facilitate the usage of low power/low cost ARM devices for blockchain nodes.
-2. Provide general purpose tools to help you run your own consensus node on whatever blockchain you want using a low power ARM device
+2. Provide general purpose tools to help individuals run their own consensus node on whatever blockchain they want using a low power ARM device
 3. Optimize for the intermediate to experienced developers (customization > convenience)
 
 ## Non goals
@@ -24,12 +24,11 @@ Really, this project is just a Ubuntu based ARM image that you can customize and
 This project is a fork of the [Ethereum on ARM project](https://github.com/diglos/ethereumonarm). That is a great project with a well defined mission and a strategy that makes sense. This project has different goals, and therefore takes a different strategy. Primary differences below:
 
 1. This project does not include any ethereum specific software, while the Ethereum on ARM project does.
-2. While this project is unopinionated about blockchain specific software, it *is* opinionated about hardening security by default and includes additional security features that make sense across blockchains.
-
+2. While this project is *not* opinionated about blockchain specific software, it *is* opinionated about hardening security by default and includes additional security features that make sense across blockchains.
 
 # How it works
 
-## At a glance
+## Expected flow
 
 1. Fork the repo (if you want)
 2. Clone the repo
@@ -37,14 +36,13 @@ This project is a fork of the [Ethereum on ARM project](https://github.com/diglo
 4. Compile the image
 5. Flash your MicroSD card, power on your device, and go on your merry way installing whatever blockchain specific applications you want. You are on your own at this point.
 
-
 ## Read the source
 
 We encourage you to read image-builder/make.sh **and** image-builder/sources/etc/rc.local line by line for several reasons:
 
 1) You should understand what it is doing, and how it works.
 2) Then you can customize it and shape it to your liking. Push your opinionated changes back up to your fork, so you can reproduce this image whenever you want.
-3) Build trust in the project, and encourage you to contribute back to it with whatever improvements you come up with that you think add value.
+3) Build trust in the project, and encourage you to contribute back to it with whatever improvements you come up with that you think add value to everyone.
 4) It's actually not that much code. If you don't understand a line, or what the flags mean, look it up and take advantage of the learning opportunity. Or just ask.
 
 ## What is included in the image

--- a/docs/configure-zram-swap.md
+++ b/docs/configure-zram-swap.md
@@ -1,0 +1,1 @@
+https://haydenjames.io/raspberry-pi-performance-add-zram-kernel-parameters/

--- a/docs/configure-zramlog.md
+++ b/docs/configure-zramlog.md
@@ -1,0 +1,1 @@
+https://pimylifeup.com/raspberry-pi-log2ram/

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -68,29 +68,6 @@ Generally, these are the steps you will need to take
 The image compilation script is configured to copy all of the contents of image-builder/packages/ into the image.
 The image rc.local script later installs all of the packages it finds in that directory on first run. This makes the image-builds/packages/ dir an ideal place to put any packages that you want to get automatically installed in your image on first run.
 
-**Install ethereumonarm-armbian-extras**
-
-One package that is **strongly recommended** to configure here is ethereumonarm-armbian-extras from the ethereum on arm project.
-The name of that package implies that it is specific to Ethereum, but it's not. All it does is re-package the ZRAM + swap scripts from the armbian project and tune it for the needs of the RPi 4 Model B. By installing that package, you automatically get a swap config, and ZRAM config with sensible defaults.
-
-For convenience, the ethereum on arm project is included as a submodule of this repo at submodules/ethereumonarm. You can also install this package directly from their APT server, but because this project values trustlessness, here are the instructions for compiling it from source.
-
-```bash
-git submodule update --init --recursive # "Inflate" git submodules, run from repo root
-cd submodules/ethereumonarm/fpm-package-builder/ethereumonarm-armbian-extras
-make deb # Make sure you run this from vagrant VM, which has build dependencies installed
-cd ../../../../ # This takes us back to the repository root
-cp submodules/ethereumonarm/fpm-package-builder/packages/ethereumonarm-armbian-extras_2.0.0-0_all.deb image-builder/packages
-```
-
-Alternatively, if you would prefer to just install the version of the package that is distributed from the ethereum on arm APT server, you can do that like this
-
-```bash
-apt-key adv --keyserver keyserver.ubuntu.com --recv-keys 8A584409D327B0A5
-add-apt-repository -n "deb http://apt.ethraspbian.com focal main"
-sudo apt-get -y install ethereumonarm-armbian-extras 
-```
-
 ### Make your own customizations
 
 You are encouraged to make whatever other changes you want.
@@ -105,7 +82,6 @@ Some ideas:
 - Set a static ip
 - Configure a firewall
 - Rename the default linux user
-- Change the swap + ZRAM config to fit your needs
 
 ## Compile the image
 
@@ -120,3 +96,12 @@ When you are ready prepare the image, run the following command from the ```imag
 1. Download and install the [Raspberry Pi Imager](https://www.raspberrypi.org/software/)
 2. Launch it, select your compiled image, and your MicroSD card, and hit continue. This will take a few minutes to write to disk and verify.
 3. Eject and insert into your device, and boot it up!
+
+## Go through post-install setup
+
+Some ideas to consider
+- [Update your OS](update_os.md)
+- [Configure ZRAM swap](configure-zram-swap.md)
+- [Configure ZRAM log rotation on /var/log](configure-zramlog.md)
+- [Configure a UFW firewall](configure-firewall.md)
+- [Test the performance of your SSD](test-ssd.md)

--- a/image-builder/make.sh
+++ b/image-builder/make.sh
@@ -10,7 +10,7 @@ pubKeyPath="sources/etc/skel/ethereum-server.pub"
 googleAuthenticatorPath="sources/etc/skel/.google_authenticator"
 
 # Optional config
-imageName="arm_node_tools.img" # Customize the output image filename
+imageName="arm_node_tools_solo_no_armbian_extras.img" # Customize the output image filename
 DISTRIBUTED_PKGS="/tmp/ubuntu_iso/opt/arm_node_tools_dist_pkgs"
 
 if [ -z "$pubKeyPath" ]; then

--- a/image-builder/make.sh
+++ b/image-builder/make.sh
@@ -10,7 +10,7 @@ pubKeyPath="sources/etc/skel/ethereum-server.pub"
 googleAuthenticatorPath="sources/etc/skel/.google_authenticator"
 
 # Optional config
-imageName="arm_node_tools_solo_no_armbian_extras.img" # Customize the output image filename
+imageName="arm_node_tools.img" # Customize the output image filename
 DISTRIBUTED_PKGS="/tmp/ubuntu_iso/opt/arm_node_tools_dist_pkgs"
 
 if [ -z "$pubKeyPath" ]; then

--- a/image-builder/sources/etc/rc.local
+++ b/image-builder/sources/etc/rc.local
@@ -13,11 +13,13 @@
 # This script turns the Ubuntu 64 bit image into an Ethereum on ARM image
 #
 
+HOST_NAME_PREFIX="ethereumonarm"
+
 # SSH port generation tool - https://www.random.org/integers/?num=5&min=1024&max=49141&col=5&base=10&format=html&rnd=new
 SSH_PORT=22 # [Optional] Set a random port # from 1024 thru 49141 - check for conflicts https://en.wikipedia.org/wiki/List_of_TCP_and_UDP_port_numbers
 
-FORMAT_DRIVE=0 # Set to 1 to format the drive with an ext4 partition
-DRIVE_MOUNT_PATH=/media/ethereum # Path used to mount the drive
+FORMAT_DRIVE=1 # Set to 1 to format the drive with an ext4 partition
+DRIVE_MOUNT_PATH=/mnt/ethereum # Path used to mount the drive
 
 # https://www.coincashew.com/coins/overview-eth/guide-or-security-best-practices-for-a-eth2-validator-beaconchain-node#secure-shared-memory
 INSTALL_SECURE_SHARED_MEMORY=1
@@ -28,8 +30,7 @@ INSTALL_FAIL_2_BAN=1
 FAIL_2_BAN_IGNORE_IP="127.0.0.1/8" # [Recommended] Add your LAN network in CIDR notation (seperated by whitespace)
 
 # Install all deb packages pre-distributed with this image
-INSTALL_DIST_PKGS=1
-INSTALL_ARMBIAN_EXTRAS_DEPS=1 # Leave this on if you included ethereum-armbian-extras with this image (recommended), to manually install its dependencies
+INSTALL_DIST_PKGS=0
 DISTRIBUTED_PKGS="/opt/arm_node_tools_dist_pkgs"
 
 FLAG="/root/first-run.flag"
@@ -40,7 +41,7 @@ if [ ! -f $FLAG ]; then
   # Modify hostname (ethereumonarm-$MAC-HASH-CHUNK)
   echo Changing hostname
   MAC_HASH=`cat /sys/class/net/eth0/address | sha256sum | awk '{print substr($0,0,9)}'`
-  echo ethereumonarm-$MAC_HASH > /etc/hostname
+  echo $HOST_NAME_PREFIX-$MAC_HASH > /etc/hostname
   sed -i "s/127.0.0.1.*/127.0.0.1\tethereumonarm-$MAC_HASH/g" /etc/hosts
   # Create Ethereum account for ssh access
   echo "Creating ethereum user"
@@ -165,32 +166,9 @@ if [ ! -f $FLAG ]; then
     echo "Installing distributed packages that came with this image..."
     ls $DISTRIBUTED_PKGS
 
-    if [[ $INSTALL_ARMBIAN_EXTRAS_DEPS -eq 1 ]];
-    then
-      # dc is technically required by the deb, even though that doesn't really make sense
-      apt-get -y install dphys-swapfile dc # Manually install the dependencies of ethereumonarm-armbian-extras, since dpkg isn't smart enough to do this automatically
-    fi
-    
     # Recursively install all deb packages at $DISTRIBUTED_PKGS
     dpkg --install --recursive $DISTRIBUTED_PKGS
   fi
-
-
-  # https://haydenjames.io/raspberry-pi-performance-add-zram-kernel-parameters/
-  # Page allocation error workout
-  echo "vm.min_free_kbytes=65536" >> /etc/sysctl.conf
-  # Increasing how aggressively the kernel will swap memory pages since we are using ZRAM first
-  echo "vm.swappiness=100" >> /etc/sysctl.conf
-  # Increases cache pressure, which increases the tendency of the kernel to reclaim memory used for caching of directory and inode objects. You will use less memory over a longer period of time
-  echo "vm.vfs_cache_pressure=500" >> /etc/sysctl.conf
-  # Background processes will start writing right away when it hits the 1% limit but the system won’t force synchronous I/O until it gets to 50% dirty_ratio
-  echo "vm.dirty_background_ratio=1" >> /etc/sysctl.conf
-  echo "vm.dirty_ratio=50" >> /etc/sysctl.conf
-
-  sed -i "s|#CONF_SWAPFILE=/var/swap|CONF_SWAPFILE=$DRIVE_MOUNT_PATH/swapfile|g" /etc/dphys-swapfile
-  sed -i 's/#CONF_SWAPSIZE=/CONF_SWAPSIZE=8192/' /etc/dphys-swapfile
-  sed -i 's/#CONF_MAXSWAP=2048/CONF_MAXSWAP=8192/' /etc/dphys-swapfile
-  systemctl enable dphys-swapfile
 
   shred -u ~/.bash_history && touch ~/.bash_history
 


### PR DESCRIPTION
My PR in ethereumonarm hasn't been reviewed with the changes we would need to continue to re-use the armbian extras package

While that package is neat and contains a bunch of bells and whistles ported over from the armbian project, it's not irreplaceable and it's probably for the best to not try to package an opinionated swap/ramlogging solution for a general purpose project like this

So I've decided to remove that dependency and instead leave documentation to suitable alternatives